### PR TITLE
Add support for pragmas with no spaces:

### DIFF
--- a/black_disable_checker/__main__.py
+++ b/black_disable_checker/__main__.py
@@ -4,7 +4,12 @@ import argparse
 import sys
 from typing import List, Union
 
-DISABLES_PRAGMAS = {"# fmt: skip", "# yapf: disable", "# fmt: off"}
+DISABLES_PRAGMAS = {
+    "# fmt:off",
+    "# fmt: off",
+    "# fmt: skip",
+    "# fmt:skip",
+    "# yapf: disable"}
 
 
 def main(argv: Union[List[str], None] = None) -> int:

--- a/black_disable_checker/__main__.py
+++ b/black_disable_checker/__main__.py
@@ -9,7 +9,8 @@ DISABLES_PRAGMAS = {
     "# fmt: off",
     "# fmt: skip",
     "# fmt:skip",
-    "# yapf: disable"}
+    "# yapf: disable",
+}
 
 
 def main(argv: Union[List[str], None] = None) -> int:

--- a/tests/fixture_fmt_off_no_space.py
+++ b/tests/fixture_fmt_off_no_space.py
@@ -1,0 +1,3 @@
+# fmt:off
+import argparse, re, sys, math
+# fmt: on

--- a/tests/fixture_fmt_skip_no_space.py
+++ b/tests/fixture_fmt_skip_no_space.py
@@ -1,0 +1,1 @@
+import argparse, re, sys, math  # fmt:skip

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,7 +19,9 @@ def test_integration_no_args() -> None:
     "file_path,expected",
     [
         ["fmt_off", "Please do not use '# fmt: off'"],
+        ["fmt_off_no_space", "Please do not use '# fmt:off'"],
         ["fmt_skip", "Please do not use '# fmt: skip'"],
+        ["fmt_skip_no_space", "Please do not use '# fmt:skip'"],
         ["yapf_disable", "Please do not use '# yapf: disable'"],
         ["multiple", "Please do not use '# fmt: skip', or '# yapf: disable'"],
     ],


### PR DESCRIPTION
After some digging around it seems `black` also allows the following format without spaces:
`# fmt:off`
`# fmt:skip`

https://github.com/psf/black/blob/44d5da00b520a05cd56e58b3998660f64ea59ebd/src/black/comments.py#L26-#L27